### PR TITLE
Fix keystone_admin_user roles directive.

### DIFF
--- a/keystone/keystone.sls
+++ b/keystone/keystone.sls
@@ -36,8 +36,8 @@ keystone_admin_user:
     - tenant: admin
     - enable: True
     - roles:
-      - admin:
-        - admin
+        admin:
+          - admin
 
 keystone_keystone_service:
   keystone.service_present:


### PR DESCRIPTION
The tenant (admin) under roles was (incorrectly) a list rather than a dictionary.
