### PR TITLE
Allow running with absent keystone:config pillar

### DIFF
--- a/keystone/map.jinja
+++ b/keystone/map.jinja
@@ -38,7 +38,7 @@
   }
 } %}
 
-{% for section, value in salt["pillar.get"]("keystone:config").iteritems() %}
+{% for section, value in salt["pillar.get"]("keystone:config", {}).iteritems() %}
   {% if not keystone_config.has_key(section) %}
     {% do keystone_config.update({ section:{} }) %}
   {% endif %}


### PR DESCRIPTION
Just added default value for pillar.get
